### PR TITLE
Feature/enum

### DIFF
--- a/calculator/ViewController.swift
+++ b/calculator/ViewController.swift
@@ -153,6 +153,8 @@ class ViewController: UIViewController {
                 return operand1 - operand2
             case .plus:
                 return operand1 + operand2
+            case .none:
+                return operand2
         }
     }
 

--- a/calculator/ViewController.swift
+++ b/calculator/ViewController.swift
@@ -153,8 +153,6 @@ class ViewController: UIViewController {
                 return operand1 - operand2
             case .plus:
                 return operand1 + operand2
-            default:
-                return operand2
         }
     }
 


### PR DESCRIPTION
> enumでswichかくと、default書かなくて良くなる。
> というより、defaultを外しておくことで、enumが追加されたときにエラーが出て、修正すべき箇所がわかる

ということで直した


関連PR: #9